### PR TITLE
Revert "Interim for changeover to named as openjdk8"

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,15 +13,9 @@ var nightly = gh.getRepo('AdoptOpenJDK', 'openjdk-nightly');
 releases.listReleases(function(err, result) {
     fs.writeFileSync('releases.json', JSON.stringify(result, null, 2))
     fs.writeFileSync('latest_release.json', JSON.stringify(result[0], null, 2))
-
-    fs.writeFileSync('releases_openjdk8.json', JSON.stringify(result, null, 2))
-    fs.writeFileSync('latest_release_openjdk8.json', JSON.stringify(result[0], null, 2))
 });
 
 nightly.listReleases(function(err, result) {
     fs.writeFileSync('nightly.json', JSON.stringify(result, null, 2))
     fs.writeFileSync('latest_nightly.json', JSON.stringify(result[0], null, 2))
-
-    fs.writeFileSync('nightly_openjdk8.json', JSON.stringify(result, null, 2))
-    fs.writeFileSync('latest_nightly_openjdk8.json', JSON.stringify(result[0], null, 2))
 });


### PR DESCRIPTION
Reverts AdoptOpenJDK/openjdk-website-backend#3

This is because we're now likely doing this with separate repositories for future variants such as OpenJDK 9, which makes more sense, because all of the releases and the corresponding JSON files will be in the same place.