### PR TITLE
Reuse a release to append different platform sdk per same release tag

### DIFF
--- a/upload.js
+++ b/upload.js
@@ -35,7 +35,7 @@ publishRelease({
   draft: false,
   prerelease: false,
   reuseRelease: true,
-  reuseDraftOnly: true,
+  reuseDraftOnly: false,
   assets: options.files,
 }, function(err, release) {
   if (err) {


### PR DESCRIPTION
We'd like to set nightly builds deployment per platform
https://github.com/AdoptOpenJDK/openjdk-build/pull/291 .

Current publishRelease API option do not allow same tag( or release) being used again. We'd like each  release can be overidden with same sdk and be appended by different platform sdk as long as those sdk is deployed at same day.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>