### PR TITLE
Fix dropped "JDK" portion of file name

### DIFF
--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -33,12 +33,12 @@ do
     EXTENSION=${BASH_REMATCH[5]};
     echo "version:${VERSION} arch: ${ARCH} os:${OS} timestampOrTag:${TS_TAG} extension: ${EXTENSION}"; 
   fi
-  mv $file "Open${VERSION}_${ARCH}_${OS}_${TS_TAG}.${EXTENSION}"
+  mv $file "OpenJDK${VERSION}_${ARCH}_${OS}_${TS_TAG}.${EXTENSION}"
   if [ "$EXTENSION" == "zip" ]; 
   then
     FILENAME=`cat $file | awk  '{print $2}'`
-    sed -i -e "s/${FILENAME}/Open${VERSION}_${ARCH}_${OS}_${TS_TAG}.${EXTENSION}/g" $file
-    mv $file "Open${VERSION}_${ARCH}_${OS}_${TS_TAG}.sha256.txt"
+    sed -i -e "s/${FILENAME}/OpenJDK${VERSION}_${ARCH}_${OS}_${TS_TAG}.${EXTENSION}/g" $file
+    mv $file "OpenJDK${VERSION}_${ARCH}_${OS}_${TS_TAG}.sha256.txt"
   fi
 done
 


### PR DESCRIPTION
Previously VERSION string contained JDK, current VERSION does not, so need to include JDK in the file name when moving files around

Signed-off-by: smlambert <slambert@gmail.com>