### PR TITLE
Handle 'banner.handlebars' being removed

### DIFF
--- a/jenkins_jobs/production.sh
+++ b/jenkins_jobs/production.sh
@@ -20,7 +20,6 @@ if [ $0 != 0 ]; then
     git add -f sitemap.xml
     git add -f robots.txt
     git add -f src/handlebars/partials/header.handlebars
-    git add -f src/handlebars/banner.handlebars
     # Revert the handlebars file as we now have the build html file
     # Commit these files to Master, then retrieve the entire repo
     # (including build output) in the gh-pages branch:

--- a/jenkins_jobs/staging.sh
+++ b/jenkins_jobs/staging.sh
@@ -9,7 +9,7 @@ cd $PR_NUMBER
 git fetch origin $GIT_REMOTE_REF:testBranch
 git checkout testBranch
 
-cat >"src/handlebars/banner.handlebars" <<-EOF
+cat >>"src/handlebars/partials/header.handlebars" <<-EOF
 <div class="alert align-center">
  <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
  This is a staging server, currently hosting <a class="light-link" href="https://github.com/AdoptOpenJDK/openjdk-website/pull/$PR_NUMBER"><var>PR $PR_NUMBER</var></a>
@@ -28,8 +28,6 @@ if [ $0 != 0 ]; then
     git add -f *.html
     git add -f sitemap.xml
     git add -f robots.txt
-    # Revert the handlebars file as we now have the build html file
-    git checkout -- src/handlebars/banner.handlebars
     # Commit these files to Master, then retrieve the entire repo
     # (including build output) in the gh-pages branch:
     git commit -m "Add built files"


### PR DESCRIPTION
adoptopenjdk/openjdk-website@e94063ffe72609743e44849eed13ef4548c2b616 removed `src/handlebars/banner.handlebars`, so this is to update the scripts for [`adoptopenjdk-website-staging`](https://ci.adoptopenjdk.net/view/Website/job/adoptopenjdk-website-staging/) and [`adoptopenjdk-website-production`](https://ci.adoptopenjdk.net/view/Website/job/adoptopenjdk-website-production/).