### PR TITLE
Also release '*sources*' artefacts (not just *hotspot*)

### DIFF
--- a/adopt-github-release/src/main/groovy/net/adoptium/release/UploadFiles.groovy
+++ b/adopt-github-release/src/main/groovy/net/adoptium/release/UploadFiles.groovy
@@ -33,7 +33,9 @@ class UploadAdoptReleaseFiles {
     void release() {
         def grouped = files.groupBy {
             switch (it.getName()) {
+                // Only release file names containing "hotspot" or "sources"
                 case ~/.*hotspot.*/: "adopt"; break;
+                case ~/.*sources.*/: "adopt"; break;
             }
         }
         GHRepository repo = getRepo("adopt")


### PR DESCRIPTION
Currently the file name matcher handles files containing
'hotspot'. This won't work for a sources artefact like:

OpenJDK8U-sources_2021-10-11-18-05.tar.gz

Also match 'sources'-containing files for the upload.

Related: https://github.com/adoptium/temurin-build/issues/2728